### PR TITLE
Zwj

### DIFF
--- a/src/components/Pagination/index.vue
+++ b/src/components/Pagination/index.vue
@@ -94,6 +94,7 @@ export default {
 .pagination-container {
   background: #fff;
   padding: 32px 16px;
+  overflow-x:auto;
 }
 .pagination-container.hidden {
   display: none;

--- a/src/router/modules/account.js
+++ b/src/router/modules/account.js
@@ -3,7 +3,7 @@ import Layout from '@/layout'
 const accountRouter = {
   path: '/account',
   component: Layout,
-  redirect: 'noredirect',
+  // redirect: 'noredirect',
   meta: {
     title: 'account',
     icon: 'user'

--- a/src/router/modules/doc.js
+++ b/src/router/modules/doc.js
@@ -3,7 +3,7 @@ import Layout from '@/layout'
 export default {
   path: '/doc',
   component: Layout,
-  redirect: 'noredirect',
+  // redirect: 'noredirect',
   meta: {
     title: 'doc',
     icon: 'documentation'

--- a/src/router/modules/management.js
+++ b/src/router/modules/management.js
@@ -3,7 +3,7 @@ import Layout from '@/layout'
 const managementRouter = {
   path: '/management',
   component: Layout,
-  redirect: 'noredirect',
+  // redirect: 'noredirect',
   meta: {
     title: 'management',
     icon: 'user'


### PR DESCRIPTION
比如 首页/管理/课程管理 点击管理时，以前是重定向到404页面。现在是跳转到/management这个路径。